### PR TITLE
release changes for 1.5.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
         // Define the binary target for the shared framework.
         .binaryTarget(
             name: "SwiftOnboardingComponentsShared",
-            url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/1.5.5/SwiftOnboardingComponentsShared.xcframework.zip",
-            checksum: "261ac336ae9dc79a5e75015626e2a7c614c7d520a4dd8fa5c76316379d3abe17"
+            url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/1.5.6/SwiftOnboardingComponentsShared.xcframework.zip",
+            checksum: "a673f2bc2c12262afacff3ccb3df050036758b172a0afbc7542c41df5a145cbb"
         ),
         .target(
             name: "Footprint",

--- a/Sources/Footprint/Footprint.swift
+++ b/Sources/Footprint/Footprint.swift
@@ -250,7 +250,9 @@ public final class FootprintHosted: Sendable {
         onError: ((String) -> Void)? = nil,
         appearance: FootprintAppearance? = nil,
         options: FootprintOptions? = nil,
-        sessionId: String? = nil
+        sessionId: String? = nil,
+        bifrostBaseUrlOverride: String? = nil,
+        apiBaseUrlOverride: String? = nil
     ) {
         Footprint.shared.sendSdkVersionInfo(
             authToken: authToken,
@@ -268,7 +270,9 @@ public final class FootprintHosted: Sendable {
             onError: onError,
             appearance: appearance,
             options: options,
-            sessionId: sessionId
+            sessionId: sessionId,
+            bifrostBaseUrlOverride: bifrostBaseUrlOverride,
+            apiBaseUrlOverride: apiBaseUrlOverride
         )
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 ### Changelog for Swift onboarding components SDK
 *Updating this file is one of the requirements for GitHub CI/CD for Swift package release*
 
+# 1.5.6
+Add internal baseUrl overrides for automated testing to enhance stability of releases. No changes required on the client side.
+
 # 1.5.5
 Add internal tracking for SDK version to we can upgrade clients when their version is outdated. No changes required on the client side.
 


### PR DESCRIPTION
This PR adds internal baseUrl overrides for automated testing to enhance stability of releases and releases as 1.5.6.