### PR TITLE
release 1.5.6 for cocoapods

### DIFF
--- a/FootprintOnboardingComponents.podspec
+++ b/FootprintOnboardingComponents.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = 'FootprintOnboardingComponents'
     # Do not change this line as it is automatically updated by the GitHub action
-    s.version          = '1.5.5'
+    s.version          = '1.5.6'
     s.summary          = 'A package for Swift onboarding components.'
     s.description      = <<-DESC
     Footprint-powered onboarding flows to your application

--- a/changelog-cocoapods.md
+++ b/changelog-cocoapods.md
@@ -1,5 +1,8 @@
 ### Changelog for FootprintOnboardingComponents CocoaPod
 
+# 1.5.6
+Add internal baseUrl overrides for automated testing to enhance stability of releases. No changes required on the client side.
+
 # 1.5.5
 Add internal tracking for SDK version to we can upgrade clients when their version is outdated. No changes required on the client side.
 


### PR DESCRIPTION
Add internal baseUrl overrides for automated testing to enhance stability of releases. No changes required on the client side.

Release 1.5.6 for cocoapods