### PR TITLE
Remove unused Plaid/LinkKit dependency

### DIFF
--- a/FootprintOnboardingComponents.podspec
+++ b/FootprintOnboardingComponents.podspec
@@ -30,5 +30,4 @@ Pod::Spec.new do |s|
     # Dependencies
     s.dependency 'FingerprintPro', '~> 2.10'
     s.dependency 'MoneyKit', '1.11.2'
-    s.dependency 'Plaid', '~> 6.4'
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "046e49cd63b46719e360254cdfaa569797b7ac7ccee6728c14886ad01392a608",
+  "originHash" : "a47986422d8eb3e3288d41aca8a9784f0a4e621173786ff47596b59f806a084b",
   "pins" : [
     {
       "identity" : "fingerprintjs-pro-ios",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "112fb07f1296605e1dfc91d7bdc5af76786520f0",
         "version" : "1.11.2"
-      }
-    },
-    {
-      "identity" : "plaid-link-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/plaid/plaid-link-ios",
-      "state" : {
-        "revision" : "24a692f9dba3a933cd1703d328e4f3cf174663ea",
-        "version" : "6.4.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/fingerprintjs/fingerprintjs-pro-ios", from: "2.10.0"),
-        .package(url: "https://github.com/moneykit/moneykit-ios", exact: "1.11.2"),
-        .package(url: "https://github.com/plaid/plaid-link-ios", from: "6.4.2")
+        .package(url: "https://github.com/moneykit/moneykit-ios", exact: "1.11.2")
     ],
     targets: [
         // Define the binary target for the shared framework.
@@ -32,8 +31,7 @@ let package = Package(
             dependencies: [
                 "SwiftOnboardingComponentsShared",
                 .product(name: "FingerprintPro", package: "fingerprintjs-pro-ios"),
-                .product(name: "MoneyKit", package: "moneykit-ios"),
-                .product(name: "LinkKit", package: "plaid-link-ios")
+                .product(name: "MoneyKit", package: "moneykit-ios")
             ]
         )
     ]


### PR DESCRIPTION
LinkKit was declared in Package.swift and the podspec but is never imported by our sources, not referenced by the shared binary, and not required by MoneyKit (which declares no dependencies and does not dynamically load it). Removing it fixes the 'LinkKit' target-name collision customers hit when they also depend on plaid-link-ios-spm, and trims consumer binaries.

Verified: SDK + the bank-linking example app build, launch, and complete a live MoneyKit bank link with zero Plaid in the bundle.