### PR TITLE
Footprint: add initialize(), deprecate initializeWith* (deprecate-first)

### DIFF
--- a/Sources/Footprint/Footprint.swift
+++ b/Sources/Footprint/Footprint.swift
@@ -62,6 +62,40 @@ public final class Footprint: Sendable {
         }
     }
     
+    public func initialize(
+        authToken: String,
+        sandboxOutcome: SandboxOutcome? = nil,
+        l10n: FootprintL10n? = nil,
+        sessionId: String? = nil
+    ) async throws -> FootprintAuthRequirement {
+        let response = try await SwiftOnboardingComponentsShared._Footprint.shared.initialize(
+            authToken: authToken,
+            sandboxOutcome: sandboxOutcome,
+            l10n: l10n,
+            sessionId: sessionId
+        )
+
+        // Use actor to set API key safely
+        await Self.propManager.setFingerprintAPIKey(response.fingerprintApiKey)
+        await Self.propManager.setSessionId(sessionId)
+        let requiresAuth = response.requiresAuth
+        if(!requiresAuth){
+            await sendFingerprintData()
+        }
+        return FootprintAuthRequirement(requiresAuth: requiresAuth)
+    }
+
+    @available(*, deprecated, renamed: "initialize", message: "Use initialize(authToken:) with an onboarding session token.")
+    public func initializeWithAuthToken(
+        authToken: String,
+        sandboxOutcome: SandboxOutcome? = nil,
+        l10n: FootprintL10n? = nil,
+        sessionId: String? = nil
+    ) async throws -> FootprintAuthRequirement {
+        try await initialize(authToken: authToken, sandboxOutcome: sandboxOutcome, l10n: l10n, sessionId: sessionId)
+    }
+
+    @available(*, deprecated, message: "Public-key initialization is deprecated. Create an onboarding session token on your backend and use initialize(authToken:) instead.")
     public func initializeWithPublicKey(
         publicKey: String,
         sandboxOutcome: SandboxOutcome? = nil,
@@ -77,29 +111,6 @@ public final class Footprint: Sendable {
         // Use actor to set API key safely
         await Self.propManager.setFingerprintAPIKey(response.fingerprintApiKey)
         await Self.propManager.setSessionId(sessionId)
-    }
-    
-    public func initializeWithAuthToken(
-        authToken: String,
-        sandboxOutcome: SandboxOutcome? = nil,
-        l10n: FootprintL10n? = nil,
-        sessionId: String? = nil
-    ) async throws -> FootprintAuthRequirement {
-        let response = try await SwiftOnboardingComponentsShared._Footprint.shared.initializeWithAuthToken(
-            authToken: authToken,
-            sandboxOutcome: sandboxOutcome,
-            l10n: l10n,
-            sessionId: sessionId
-        )
-        
-        // Use actor to set API key safely
-        await Self.propManager.setFingerprintAPIKey(response.fingerprintApiKey)
-        await Self.propManager.setSessionId(sessionId)
-        let requiresAuth = response.requiresAuth
-        if(!requiresAuth){
-            await sendFingerprintData()
-        }
-        return FootprintAuthRequirement(requiresAuth: requiresAuth)
     }
     
     // Rest of the methods remain unchanged

--- a/Sources/FootprintBankLinking/FootprintBankLinking.swift
+++ b/Sources/FootprintBankLinking/FootprintBankLinking.swift
@@ -128,7 +128,7 @@ public struct FootprintBankLinking: View {
         .onAppear {
             Task {
                 do {
-                    try await Footprint.shared.initializeWithAuthToken(
+                    try await Footprint.shared.initialize(
                         authToken: authToken,
                         sessionId: sessionId
                     )


### PR DESCRIPTION
Deprecate-first: adds a single **`initialize(authToken:)`** and marks the old init methods deprecated. This is the external-repo half of the "single `initialize`" change (monorepo `#29865` does the KMM side; footprint-expo shipped it in `#29859`).

## What
- New `Footprint.shared.initialize(authToken:sandboxOutcome:l10n:sessionId:)`.
- `initializeWithAuthToken` → `@available(*, deprecated, renamed: "initialize")`, forwards to `initialize`.
- `initializeWithPublicKey` → `@available(*, deprecated, …)`, still fully functional this version (public-key init + its plumbing stay; both come out next major).
- `FootprintBankLinking` internal caller updated to `initialize`.

## ⚠️ Blocked on the shared xcframework
`initialize` calls `_Footprint.shared.initialize`, which only exists after the KMM change in **onefootprint/monorepo#29865** is built into `SwiftOnboardingComponentsShared.xcframework`. Until a fresh xcframework is dropped in (via `packForXcode`), this **won't compile**. Draft until then.

## Not done here (belongs in the release cycle)
- Bumping `Package.ios.kt` version + `changelog.md` / `changelog-cocoapods.md` and the actual SPM/CocoaPods release — do these as part of the next iOS release once the xcframework lands.
