### PR TITLE
feat: native document capture (opt-in FootprintDocumentCapture product)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,10 +19,19 @@ let package = Package(
             name: "FootprintBankLinking",
             targets: ["FootprintBankLinking"]
         ),
+        // Opt-in native document capture. Pulls in the camera module; only link this if you
+        // collect ID documents inline (otherwise document collection uses the hosted flow).
+        .library(
+            name: "FootprintDocumentCapture",
+            targets: ["FootprintDocumentCapture"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/fingerprintjs/fingerprintjs-pro-ios", from: "2.10.0"),
-        .package(url: "https://github.com/moneykit/moneykit-ios", exact: "1.11.2")
+        .package(url: "https://github.com/moneykit/moneykit-ios", exact: "1.11.2"),
+        // Local path to the shared camera module's Swift package (monorepo is a sibling checkout).
+        // TODO(release): replace with a git-tagged SPM release of FootprintNativeCameraSwift.
+        .package(path: "../monorepo/mobile/packages/footprint-native-camera-module/FootprintNativeCameraSwift")
     ],
     targets: [
         // Define the binary target for the shared framework.
@@ -44,6 +53,14 @@ let package = Package(
                 "Footprint",
                 "SwiftOnboardingComponentsShared",
                 .product(name: "MoneyKit", package: "moneykit-ios")
+            ]
+        ),
+        .target(
+            name: "FootprintDocumentCapture",
+            dependencies: [
+                "Footprint",
+                "SwiftOnboardingComponentsShared",
+                .product(name: "FootprintNativeCameraSwift", package: "FootprintNativeCameraSwift")
             ]
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Footprint",
     platforms: [
-        // Raised to iOS 16 because the opt-in FootprintDocumentCapture product depends on
-        // FootprintNativeCameraSwift, which requires iOS 16. SPM platforms are package-wide,
-        // so this also applies to the core Footprint / FootprintBankLinking products.
-        .iOS(.v16)
+        .iOS(.v14)
     ],
     products: [
         // Core onboarding/KYC. Consumers who only need onboarding link this.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,10 @@ import PackageDescription
 let package = Package(
     name: "Footprint",
     platforms: [
-        .iOS(.v14) // Specify the minimum platform version
+        // Raised to iOS 16 because the opt-in FootprintDocumentCapture product depends on
+        // FootprintNativeCameraSwift, which requires iOS 16. SPM platforms are package-wide,
+        // so this also applies to the core Footprint / FootprintBankLinking products.
+        .iOS(.v16)
     ],
     products: [
         // Core onboarding/KYC. Consumers who only need onboarding link this.

--- a/Sources/Footprint/FootprintDocumentCapture.swift
+++ b/Sources/Footprint/FootprintDocumentCapture.swift
@@ -1,0 +1,163 @@
+import Foundation
+@_exported import SwiftOnboardingComponentsShared
+
+/// Options for `Footprint.captureDocument`, mirroring footprint-expo's `DocumentOptions`.
+public struct FootprintDocumentCaptureOptions: Sendable {
+    public let kind: DocumentKind
+    public let countryCode: Iso3166TwoDigitCountryCode
+    public let autoCapture: Bool
+    public let allowGalleryUpload: Bool
+
+    public init(
+        kind: DocumentKind,
+        countryCode: Iso3166TwoDigitCountryCode,
+        autoCapture: Bool = true,
+        allowGalleryUpload: Bool = true
+    ) {
+        self.kind = kind
+        self.countryCode = countryCode
+        self.autoCapture = autoCapture
+        self.allowGalleryUpload = allowGalleryUpload
+    }
+}
+
+public struct FootprintCaptureDocumentResult: Sendable {
+    public let uploadedSides: [DocumentSide]
+    public let canceled: Bool
+
+    public init(uploadedSides: [DocumentSide], canceled: Bool = false) {
+        self.uploadedSides = uploadedSides
+        self.canceled = canceled
+    }
+}
+
+/// Everything the camera package needs to present the capture UI and drive the
+/// per-side loop. The SDK creates the document and owns `uploadSide` (the network
+/// round-trip); the provider owns the capture UI.
+public struct FootprintDocumentCaptureContext: Sendable {
+    public let documentId: String
+    public let documentKind: DocumentKind
+    public let countryCode: Iso3166TwoDigitCountryCode
+    public let shouldCollectSelfie: Bool
+    public let autoCapture: Bool
+    public let allowGalleryUpload: Bool
+    public let language: String?
+    public let uploadSide: @Sendable (
+        _ imageBase64: String,
+        _ side: DocumentSide,
+        _ isManual: Bool,
+        _ fromGallery: Bool
+    ) async throws -> FootprintDocumentProcessResult
+
+    public init(
+        documentId: String,
+        documentKind: DocumentKind,
+        countryCode: Iso3166TwoDigitCountryCode,
+        shouldCollectSelfie: Bool,
+        autoCapture: Bool,
+        allowGalleryUpload: Bool,
+        language: String?,
+        uploadSide: @escaping @Sendable (String, DocumentSide, Bool, Bool) async throws -> FootprintDocumentProcessResult
+    ) {
+        self.documentId = documentId
+        self.documentKind = documentKind
+        self.countryCode = countryCode
+        self.shouldCollectSelfie = shouldCollectSelfie
+        self.autoCapture = autoCapture
+        self.allowGalleryUpload = allowGalleryUpload
+        self.language = language
+        self.uploadSide = uploadSide
+    }
+}
+
+/// Implemented by the opt-in `FootprintDocumentCapture` product and registered via
+/// `Footprint.shared.setDocumentCaptureProvider`. Without a registered provider,
+/// `Footprint.captureDocument` throws `E_NO_CAMERA_MODULE`.
+public protocol FootprintDocumentCaptureProvider: Sendable {
+    func present(_ context: FootprintDocumentCaptureContext) async throws -> FootprintCaptureDocumentResult
+}
+
+internal actor DocumentCaptureProviderStore {
+    private var provider: FootprintDocumentCaptureProvider?
+    func set(_ provider: FootprintDocumentCaptureProvider) { self.provider = provider }
+    func get() -> FootprintDocumentCaptureProvider? { provider }
+}
+
+private let documentCaptureProviderStore = DocumentCaptureProviderStore()
+
+extension Footprint {
+    /// Registered by the opt-in `FootprintDocumentCapture` product to enable `captureDocument`.
+    public func setDocumentCaptureProvider(_ provider: FootprintDocumentCaptureProvider) {
+        Task { await documentCaptureProviderStore.set(provider) }
+    }
+
+    public func hasDocumentCapture() async -> Bool {
+        await documentCaptureProviderStore.get() != nil
+    }
+
+    /// The pending `collect_document` requirement, or nil if none is pending.
+    public func getDocumentConfig() async throws -> FootprintDocumentConfig? {
+        try await SwiftOnboardingComponentsShared._Footprint.shared.getDocumentConfig()
+    }
+
+    public func submitConsent(consentLanguageText: String, mlConsent: Bool = false) async throws {
+        try await SwiftOnboardingComponentsShared._Footprint.shared.submitConsent(
+            consentLanguageText: consentLanguageText,
+            mlConsent: mlConsent
+        )
+    }
+
+    /// Collect an ID document inline. Requires the `FootprintDocumentCapture` product
+    /// (registered via `setDocumentCaptureProvider`); otherwise throws `E_NO_CAMERA_MODULE`.
+    public func captureDocument(
+        options: FootprintDocumentCaptureOptions
+    ) async throws -> FootprintCaptureDocumentResult {
+        guard let provider = await documentCaptureProviderStore.get() else {
+            throw FootprintException(
+                kind: .sdkError,
+                message: "Document capture requires the FootprintDocumentCapture product. Add it and call "
+                    + "Footprint.shared.setDocumentCaptureProvider(...), or use the hosted flow.",
+                supportId: nil,
+                sessionId: nil,
+                context: nil,
+                code: "E_NO_CAMERA_MODULE"
+            )
+        }
+        guard let config = try await getDocumentConfig() else {
+            throw FootprintException(
+                kind: .onboardingError,
+                message: "No collect_document requirement is currently pending.",
+                supportId: nil,
+                sessionId: nil,
+                context: nil,
+                code: nil
+            )
+        }
+        let documentId = try await SwiftOnboardingComponentsShared._Footprint.shared.createDocument(
+            documentRequestId: config.documentRequestId,
+            documentType: options.kind,
+            countryCode: options.countryCode,
+            shouldCollectSelfie: config.shouldCollectSelfie
+        )
+        let language = SwiftOnboardingComponentsShared._Footprint.shared.getL10n().language?.value
+        let context = FootprintDocumentCaptureContext(
+            documentId: documentId,
+            documentKind: options.kind,
+            countryCode: options.countryCode,
+            shouldCollectSelfie: config.shouldCollectSelfie,
+            autoCapture: options.autoCapture,
+            allowGalleryUpload: options.allowGalleryUpload,
+            language: language,
+            uploadSide: { imageBase64, side, isManual, fromGallery in
+                try await SwiftOnboardingComponentsShared._Footprint.shared.uploadDocumentSide(
+                    documentId: documentId,
+                    side: side,
+                    imageBase64: imageBase64,
+                    isManual: isManual,
+                    fromGallery: fromGallery
+                )
+            }
+        )
+        return try await provider.present(context)
+    }
+}

--- a/Sources/Footprint/FootprintDocumentCapture.swift
+++ b/Sources/Footprint/FootprintDocumentCapture.swift
@@ -1,6 +1,11 @@
 import Foundation
 @_exported import SwiftOnboardingComponentsShared
 
+// SKIE bridges the Kotlin FootprintException as a plain class that isn't a Swift Error,
+// so it can't be thrown as-is. Conform it retroactively so captureDocument can throw it and
+// integrators catch it like any other Footprint error.
+extension FootprintException: @retroactive Error {}
+
 /// Options for `Footprint.captureDocument`, mirroring footprint-expo's `DocumentOptions`.
 public struct FootprintDocumentCaptureOptions: Sendable {
     public let kind: DocumentKind

--- a/Sources/FootprintDocumentCapture/NativeDocumentCaptureProvider.swift
+++ b/Sources/FootprintDocumentCapture/NativeDocumentCaptureProvider.swift
@@ -1,0 +1,154 @@
+import UIKit
+import SwiftUI
+import Footprint
+import SwiftOnboardingComponentsShared
+// The Swift camera screen + the Kotlin types (CameraCaptureView / CaptureAppearance /
+// DocumentProcessResult / CaptureImageError / IosDocumentCaptureCoordinator).
+import FootprintNativeCameraSwift
+import FootprintNativeCamera
+
+/// Tracks the capture session's uploaded sides and guards single-resume of the
+/// async continuation across the several terminal callbacks.
+private final class CaptureState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resumed = false
+    private var uploaded: [DocumentSide] = []
+
+    func tryResume() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if resumed { return false }
+        resumed = true
+        return true
+    }
+
+    func record(_ side: DocumentSide) {
+        lock.lock(); defer { lock.unlock() }
+        if !uploaded.contains(side) { uploaded.append(side) }
+    }
+
+    func sides() -> [DocumentSide] {
+        lock.lock(); defer { lock.unlock() }
+        return uploaded
+    }
+}
+
+/// Presents the shared camera module's document-capture UI and routes each side's
+/// upload back through the SDK (`FootprintDocumentCaptureContext.uploadSide`).
+public final class NativeDocumentCaptureProvider: FootprintDocumentCaptureProvider {
+    public init() {}
+
+    public func present(
+        _ context: FootprintDocumentCaptureContext
+    ) async throws -> FootprintCaptureDocumentResult {
+        try await withCheckedThrowingContinuation { continuation in
+            let state = CaptureState()
+
+            // Per side: run the SDK's upload/process, map the result into the camera
+            // module's DocumentProcessResult. KMM bridges the nested lambda params as
+            // `-> KotlinUnit`, so wrap them as plain Swift closures.
+            IosDocumentCaptureCoordinator.shared.uploadSide = { imageBase64, side, isManual, fromGallery, onResult, onError in
+                let onResultVoid: (DocumentProcessResult) -> Void = { onResult($0) }
+                let onErrorVoid: (String, String) -> Void = { onError($0, $1) }
+                Task {
+                    do {
+                        let result = try await context.uploadSide(
+                            imageBase64,
+                            Self.mapSide(side),
+                            isManual,
+                            fromGallery
+                        )
+                        state.record(Self.mapSide(side))
+                        onResultVoid(DocumentProcessResult(
+                            errors: result.errors.map { CaptureImageError(code: $0, message: nil) },
+                            isRetryLimitExceeded: result.isRetryLimitExceeded,
+                            nextSideToCollect: result.nextSideToCollect?.value
+                        ))
+                    } catch {
+                        let fp = error as? FootprintException
+                        onErrorVoid(fp?.code ?? "UPLOAD_ERROR", fp?.message ?? error.localizedDescription)
+                    }
+                }
+            }
+
+            DispatchQueue.main.async {
+                guard let presenter = Self.topMostViewController() else {
+                    IosDocumentCaptureCoordinator.shared.uploadSide = nil
+                    if state.tryResume() {
+                        continuation.resume(throwing: FootprintException(
+                            kind: .sdkError,
+                            message: "Could not find a view controller to present the capture screen.",
+                            supportId: nil, sessionId: nil, context: nil, code: "NO_PRESENTER"
+                        ))
+                    }
+                    return
+                }
+
+                var host: UIHostingController<CameraCaptureView>!
+                let finish: (@escaping () -> Void) -> Void = { body in
+                    IosDocumentCaptureCoordinator.shared.uploadSide = nil
+                    host.dismiss(animated: true, completion: body)
+                }
+                let view = CameraCaptureView(
+                    startSide: "front",
+                    documentKind: context.documentKind.value,
+                    appearance: CaptureAppearance.companion.fromVariables(theme: nil, variables: [:], fontFamily: nil),
+                    language: context.language,
+                    onError: { code, message in
+                        finish {
+                            if state.tryResume() {
+                                continuation.resume(throwing: FootprintException(
+                                    kind: .onboardingError, message: message,
+                                    supportId: nil, sessionId: nil, context: nil, code: code
+                                ))
+                            }
+                        }
+                    },
+                    onComplete: {
+                        finish {
+                            if state.tryResume() {
+                                continuation.resume(returning: FootprintCaptureDocumentResult(
+                                    uploadedSides: state.sides(), canceled: false
+                                ))
+                            }
+                        }
+                    },
+                    onClose: {
+                        finish {
+                            if state.tryResume() {
+                                continuation.resume(returning: FootprintCaptureDocumentResult(
+                                    uploadedSides: [], canceled: true
+                                ))
+                            }
+                        }
+                    }
+                )
+                host = UIHostingController(rootView: view)
+                host.modalPresentationStyle = .fullScreen
+                presenter.present(host, animated: true)
+            }
+        }
+    }
+
+    private static func mapSide(_ side: String) -> DocumentSide {
+        switch side {
+        case "front": return .front
+        case "back": return .back
+        case "selfie": return .selfie
+        default: return .unknown
+        }
+    }
+
+    /// Walks to the deepest presented controller so we don't present under an existing sheet.
+    private static func topMostViewController() -> UIViewController? {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let keyWindow = scenes.flatMap { $0.windows }.first { $0.isKeyWindow } ?? scenes.first?.windows.first
+        var top = keyWindow?.rootViewController
+        while let next = top?.presentedViewController { top = next }
+        return top
+    }
+}
+
+/// One-line opt-in: registers native document capture with the Footprint SDK.
+public func registerFootprintDocumentCapture() {
+    Footprint.shared.setDocumentCaptureProvider(NativeDocumentCaptureProvider())
+}

--- a/Sources/FootprintDocumentCapture/NativeDocumentCaptureProvider.swift
+++ b/Sources/FootprintDocumentCapture/NativeDocumentCaptureProvider.swift
@@ -32,6 +32,11 @@ private final class CaptureState: @unchecked Sendable {
     }
 }
 
+private struct UploadCallbacks: @unchecked Sendable {
+    let onResult: (DocumentProcessResult) -> Void
+    let onError: (String, String) -> Void
+}
+
 /// Presents the shared camera module's document-capture UI and routes each side's
 /// upload back through the SDK (`FootprintDocumentCaptureContext.uploadSide`).
 public final class NativeDocumentCaptureProvider: FootprintDocumentCaptureProvider {
@@ -47,25 +52,24 @@ public final class NativeDocumentCaptureProvider: FootprintDocumentCaptureProvid
             // module's DocumentProcessResult. KMM bridges the nested lambda params as
             // `-> KotlinUnit`, so wrap them as plain Swift closures.
             IosDocumentCaptureCoordinator.shared.uploadSide = { imageBase64, side, isManual, fromGallery, onResult, onError in
-                let onResultVoid: (DocumentProcessResult) -> Void = { onResult($0) }
-                let onErrorVoid: (String, String) -> Void = { onError($0, $1) }
+                let mappedSide = Self.mapSide(side)
+                let manual = isManual.boolValue
+                let gallery = fromGallery.boolValue
+                // The KMM callbacks aren't Sendable; box them so the Task can capture them. They're
+                // safe to invoke off the calling thread — they resolve the module's upload continuation.
+                let callbacks = UploadCallbacks(onResult: { onResult($0) }, onError: { onError($0, $1) })
                 Task {
                     do {
-                        let result = try await context.uploadSide(
-                            imageBase64,
-                            Self.mapSide(side),
-                            isManual,
-                            fromGallery
-                        )
-                        state.record(Self.mapSide(side))
-                        onResultVoid(DocumentProcessResult(
+                        let result = try await context.uploadSide(imageBase64, mappedSide, manual, gallery)
+                        state.record(mappedSide)
+                        callbacks.onResult(DocumentProcessResult(
                             errors: result.errors.map { CaptureImageError(code: $0, message: nil) },
                             isRetryLimitExceeded: result.isRetryLimitExceeded,
                             nextSideToCollect: result.nextSideToCollect?.value
                         ))
                     } catch {
                         let fp = error as? FootprintException
-                        onErrorVoid(fp?.code ?? "UPLOAD_ERROR", fp?.message ?? error.localizedDescription)
+                        callbacks.onError(fp?.code ?? "UPLOAD_ERROR", fp?.message ?? error.localizedDescription)
                     }
                 }
             }


### PR DESCRIPTION
Adds native inline ID document capture to the iOS SDK, reusing the shared `footprint-native-camera-module` — the iOS counterpart to the Android work (onefootprint/monorepo#29914), completing platform parity with footprint-expo.

## What's here

- **New opt-in** **`FootprintDocumentCapture`** **SPM product** (mirrors `FootprintBankLinking`): a separate library the integrator links only if they collect documents inline. Depends on the camera module's `FootprintNativeCameraSwift`.
- **Core** **`Footprint`** gains `getDocumentConfig()` / `submitConsent(...)`, plus `captureDocument(options:)` and a `setDocumentCaptureProvider(_:)` seam. Without the opt-in product registered, `captureDocument` throws `E_NO_CAMERA_MODULE` (mirrors footprint-expo / Android).
- **`NativeDocumentCaptureProvider`** presents the module's `CameraCaptureView` (full-screen `UIHostingController`) and wires `IosDocumentCaptureCoordinator` so each captured side's upload routes back through `_Footprint.uploadDocumentSide` — the SDK owns the network, the module owns the UI. `registerFootprintDocumentCapture()` is the one-line opt-in.