### PR TITLE
Bundle the camera xcframeworks into FootprintDocumentCapture (SPM)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,20 +36,20 @@ let package = Package(
         // Define the binary target for the shared framework.
         .binaryTarget(
             name: "SwiftOnboardingComponentsShared",
-            url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/2.0.0/SwiftOnboardingComponentsShared.xcframework.zip",
-            checksum: "a740df0ee7aa2bad975131bcef195ed35f5db89f42046ad1db59c4e54579f264"
+            url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/2.1.0/SwiftOnboardingComponentsShared.xcframework.zip",
+            checksum: "f88fa98d4bee5c7fee429d9268b7e71f48195e4cf9d077d06d4cfed8f94a30c1"
         ),
-        // Camera binaries for FootprintDocumentCapture. url + checksum are filled in per release
-        // by update-shared-swift-binary.sh (no prior release, so the checksums are placeholders).
+        // Camera binaries for FootprintDocumentCapture. url + checksum are rewritten per release
+        // by update-shared-swift-binary.sh.
         .binaryTarget(
             name: "FootprintNativeCamera",
             url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/2.1.0/FootprintNativeCamera.xcframework.zip",
-            checksum: "REPLACE_ON_RELEASE"
+            checksum: "6f1e493e17e4d7ae1a7fa5c1cc5c790ad6302d76179fa1d2f338c882be768b0b"
         ),
         .binaryTarget(
             name: "FootprintNativeCameraSwift",
             url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/2.1.0/FootprintNativeCameraSwift.xcframework.zip",
-            checksum: "REPLACE_ON_RELEASE"
+            checksum: "76e235fbf8fd36fee5bf51a9b8f0e8ae1e6404ae42e1d69245c6a230782512fc"
         ),
         .target(
             name: "Footprint",

--- a/Package.swift
+++ b/Package.swift
@@ -29,9 +29,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/fingerprintjs/fingerprintjs-pro-ios", from: "2.10.0"),
         .package(url: "https://github.com/moneykit/moneykit-ios", exact: "1.11.2"),
-        // Local path to the shared camera module's Swift package (monorepo is a sibling checkout).
-        // TODO(release): replace with a git-tagged SPM release of FootprintNativeCameraSwift.
-        .package(path: "../monorepo/mobile/packages/footprint-native-camera-module/FootprintNativeCameraSwift")
+        // FootprintDocumentCapture's camera layer bridges KMM suspend/Flow to Swift via KMP-NativeCoroutines.
+        .package(url: "https://github.com/rickclephas/KMP-NativeCoroutines.git", exact: "1.0.2")
     ],
     targets: [
         // Define the binary target for the shared framework.
@@ -39,6 +38,18 @@ let package = Package(
             name: "SwiftOnboardingComponentsShared",
             url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/2.0.0/SwiftOnboardingComponentsShared.xcframework.zip",
             checksum: "a740df0ee7aa2bad975131bcef195ed35f5db89f42046ad1db59c4e54579f264"
+        ),
+        // Camera binaries for FootprintDocumentCapture. url + checksum are filled in per release
+        // by update-shared-swift-binary.sh (no prior release, so the checksums are placeholders).
+        .binaryTarget(
+            name: "FootprintNativeCamera",
+            url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/2.1.0/FootprintNativeCamera.xcframework.zip",
+            checksum: "REPLACE_ON_RELEASE"
+        ),
+        .binaryTarget(
+            name: "FootprintNativeCameraSwift",
+            url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/2.1.0/FootprintNativeCameraSwift.xcframework.zip",
+            checksum: "REPLACE_ON_RELEASE"
         ),
         .target(
             name: "Footprint",
@@ -60,7 +71,11 @@ let package = Package(
             dependencies: [
                 "Footprint",
                 "SwiftOnboardingComponentsShared",
-                .product(name: "FootprintNativeCameraSwift", package: "FootprintNativeCameraSwift")
+                "FootprintNativeCameraSwift",
+                "FootprintNativeCamera",
+                .product(name: "KMPNativeCoroutinesCore", package: "KMP-NativeCoroutines"),
+                .product(name: "KMPNativeCoroutinesAsync", package: "KMP-NativeCoroutines"),
+                .product(name: "KMPNativeCoroutinesCombine", package: "KMP-NativeCoroutines")
             ]
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -37,19 +37,19 @@ let package = Package(
         .binaryTarget(
             name: "SwiftOnboardingComponentsShared",
             url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/2.1.0/SwiftOnboardingComponentsShared.xcframework.zip",
-            checksum: "f88fa98d4bee5c7fee429d9268b7e71f48195e4cf9d077d06d4cfed8f94a30c1"
+            checksum: "f2a85e65d6fd9f3b555b69dc27893fc8a92bdae858ac3f7a528adeeccc2be5ca"
         ),
         // Camera binaries for FootprintDocumentCapture. url + checksum are rewritten per release
         // by update-shared-swift-binary.sh.
         .binaryTarget(
             name: "FootprintNativeCamera",
             url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/2.1.0/FootprintNativeCamera.xcframework.zip",
-            checksum: "6f1e493e17e4d7ae1a7fa5c1cc5c790ad6302d76179fa1d2f338c882be768b0b"
+            checksum: "f7a94cebf72c793977749594fd627113849ff1e4f66a27770269dd893cbdb530"
         ),
         .binaryTarget(
             name: "FootprintNativeCameraSwift",
             url: "https://github.com/onefootprint/Swift-Onboarding-Components/releases/download/2.1.0/FootprintNativeCameraSwift.xcframework.zip",
-            checksum: "76e235fbf8fd36fee5bf51a9b8f0e8ae1e6404ae42e1d69245c6a230782512fc"
+            checksum: "6d6dbbb9440df192ec105926ee8590243c729677b444759cf7c1537781f646d1"
         ),
         .target(
             name: "Footprint",

--- a/changelog-cocoapods.md
+++ b/changelog-cocoapods.md
@@ -1,5 +1,9 @@
 ### Changelog for FootprintOnboardingComponents CocoaPod
 
+# 2.1.0
+- Added a single `initialize(authToken:)`; `initializeWithAuthToken` / `initializeWithPublicKey` are deprecated (still functional this version; public-key init is removed next major).
+- Added `collect_custom_data` support. Native document capture is available via Swift Package Manager (the `FootprintDocumentCapture` product); CocoaPods support to follow. See the [native onboarding docs](https://docs.onefootprint.com/articles/sdks/swift-native).
+
 # 2.0.0
   Bank linking is now a separate, opt-in subspec, and the unused Plaid dependency has been removed.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 ### Changelog for Swift onboarding components SDK
 *Updating this file is one of the requirements for GitHub CI/CD for Swift package release*
 
+ # 2.1.0
+- Added a single `initialize(authToken:)`; `initializeWithAuthToken` / `initializeWithPublicKey` are deprecated (still functional this version; public-key init is removed next major).
+- Added the opt-in `FootprintDocumentCapture` product for native document capture, and `collect_custom_data` support. See the [native onboarding docs](https://docs.onefootprint.com/articles/sdks/swift-native).
+
  # 2.0.0
   Bank linking is now a separate, opt-in product, and the previous Plaid dependency has been removed.
 


### PR DESCRIPTION
## Describe your changes

iOS SDK **2.1.0**: bundle the camera xcframeworks into the opt-in `FootprintDocumentCapture` product, plus changelogs.

- `Package.swift`: `FootprintDocumentCapture` now depends on bundled `FootprintNativeCamera` + `FootprintNativeCameraSwift` binaryTargets (+ KMP-NativeCoroutines) instead of the local `../monorepo` path — so the release ships no camera source and needs no sibling checkout.
- `changelog.md` / `changelog-cocoapods.md` 2.1.0 (document capture is SPM-only for now; CocoaPods to follow).

## Release

Run `update-shared-swift-binary.sh 2.1.0` (in the monorepo) to fill the camera `url` + `checksum` and produce the three zips to attach to the `2.1.0` GitHub release. Verified: demo-swift builds against the bundled binaryTargets.
