### PR TITLE
chore: release cocoapods 2.1.0

### DIFF
--- a/FootprintOnboardingComponents.podspec
+++ b/FootprintOnboardingComponents.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = 'FootprintOnboardingComponents'
     # Do not change this line as it is automatically updated by the GitHub action
-    s.version          = '2.0.0'
+    s.version          = '2.1.0'
     s.summary          = 'A package for Swift onboarding components.'
     s.description      = <<-DESC
     Footprint-powered onboarding flows to your application


### PR DESCRIPTION
## Describe your changes
Publishes the CocoaPod at 2.1.0 by bumping `s.version` (pairs with the already-merged `changelog-cocoapods.md` 2.1.0 entry). Ships the single `initialize(authToken:)` + deprecations and `collect_custom_data`. Native document capture stays **SPM-only** — the pod never vendored it, so no podspec change was needed to exclude it.

## Proof
- Published to trunk: **[FootprintOnboardingComponents 2.1.0](https://cocoapods.org/pods/FootprintOnboardingComponents)** (live 2026-08-21).
- `pod lib lint` → `BUILD SUCCEEDED` for both subspecs against the `2.1.0` tag + release xcframework.

## Caveats
Pushed with `--allow-warnings` for the pre-existing missing-`LICENSE` warning (never tracked; every prior release did the same). Optional future cleanup: add a `LICENSE` file or drop `:file` from the license spec.
